### PR TITLE
Fix arguments deprecation warning that is also an error in ruby 3.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    falconz (1.0.2)
+    falconz (1.1.0)
       httparty (>= 0.16.2, < 0.19.0)
 
 GEM
@@ -13,9 +13,9 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     method_source (1.0.0)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2021.1115)
     multi_xml (0.6.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -46,4 +46,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   2.2.22

--- a/falconz.gemspec
+++ b/falconz.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/picatz/falconz"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 2.0'
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/lib/falconz/apis/search.rb
+++ b/lib/falconz/apis/search.rb
@@ -17,7 +17,7 @@ module Falconz
         options = {}
         options[:hash] = string unless string.nil?
         raise "Requires a MD5, SHA1 or SHA256 hash" if options[:hash].nil?
-        post_request("/search/hash", options)
+        post_request("/search/hash", **options)
       end
       
       # Get a summaries for any amount of given hashes.
@@ -42,7 +42,7 @@ module Falconz
         options = {}
         options[:hashes] = strings unless strings.nil? or strings.empty?
         raise "Requires MD5, SHA1 or SHA256 hashes" if options[:hashes].nil?
-        post_request("/search/hashes", options)
+        post_request("/search/hashes", **options)
       end
      
       # Search the database using search terms.

--- a/lib/falconz/version.rb
+++ b/lib/falconz/version.rb
@@ -1,3 +1,3 @@
 module Falconz
-  VERSION = "1.0.3"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
As described [here](https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments)